### PR TITLE
Set time-out builds to failed

### DIFF
--- a/qed/Functions/FailTimedOutBuilds.cs
+++ b/qed/Functions/FailTimedOutBuilds.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace qed
+{
+    public static partial class Functions
+    {
+        public static void FailTimedOutBuilds(Action<string> logConsoleMessage)
+        {
+            var timedOutbuilds = GetTimedOutBuilds();
+
+            foreach (var timedOutBuild in timedOutbuilds)
+            {
+                logConsoleMessage(String.Format("Build #{0} timed out; setting to failed.", timedOutBuild.Id));
+                AppendBuildOutput(timedOutBuild, "ERROR: The build exceeded the timeout; setting to failed.");
+                SetBuildFinished(timedOutBuild, false, DateTimeOffset.UtcNow);
+            }
+        }
+    }
+}

--- a/qed/Program.cs
+++ b/qed/Program.cs
@@ -87,6 +87,7 @@ namespace qed
                 {
                     // TODO: Do this with cancellation and timeout
                     fn.BuildNext(Console.WriteLine);
+                    fn.FailTimedOutBuilds(Console.WriteLine);
                 }
                 catch (AggregateException agEx)
                 {

--- a/qed/RavenQueries/GetTimedOutBuilds.cs
+++ b/qed/RavenQueries/GetTimedOutBuilds.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Raven.Client.Linq;
+
+namespace qed
+{
+    public static partial class Functions
+    {
+        public static IList<Build> GetTimedOutBuilds()
+        {
+            using (var ravenSession = OpenRavenSession())
+            {
+                return ravenSession.Query<Build>()
+                    .Where(build =>
+                        build.Started != null &&
+                        build.Finished == null &&
+                        build.Started < DateTimeOffset.UtcNow.AddMinutes(-5))
+                    .ToList();
+            }
+        }
+    }
+}

--- a/qed/qed.csproj
+++ b/qed/qed.csproj
@@ -171,6 +171,7 @@
     <Compile Include="RavenDocuments\User.cs" />
     <Compile Include="RavenDocuments\Build.cs" />
     <Compile Include="BuildConfiguration.cs" />
+    <Compile Include="RavenQueries\GetTimedOutBuilds.cs" />
     <Compile Include="RavenQueries\GetUsers.cs" />
     <Compile Include="RavenQueries\GetUserByUsername.cs" />
     <Compile Include="RavenQueries\GetUsersCount.cs" />

--- a/qed/qed.csproj
+++ b/qed/qed.csproj
@@ -113,6 +113,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Functions\CompareToPasswordHash.cs" />
+    <Compile Include="Functions\FailTimedOutBuilds.cs" />
     <Compile Include="Functions\ToDictionary.cs" />
     <Compile Include="Functions\GeneratePasswordHash.cs" />
     <Compile Include="Functions\GetRepositoryUrl.cs" />


### PR DESCRIPTION
After 77feedd3b17e05d39ea0858832da199551ef585f, builds that run forever should be far more unlikely, but just in case, this PR adds setting timed-out builds to failed in the run loop. Fixes #37.
