### PR TITLE
Set default db for existing raven instances #77

### DIFF
--- a/qed/Functions/CreateRavenStore.cs
+++ b/qed/Functions/CreateRavenStore.cs
@@ -23,6 +23,7 @@ namespace qed
             { 
                 ravenStore = new DocumentStore
                 {
+                    DefaultDatabase = "qed",
                     Url = GetConfiguration<string>(Constants.Configuration.RavenConnectionStringKey)
                 };
             }


### PR DESCRIPTION
Turns out you can only have multiple databases on external raven instances.  Which makes sense since you can always specify a different directory for the database file for the embedded version.
