### PR TITLE
Add initial cut at 404 page

### DIFF
--- a/qed/Functions/ConfigureBuilder.cs
+++ b/qed/Functions/ConfigureBuilder.cs
@@ -58,6 +58,7 @@ namespace qed
                 if (user == null || !user.IsAdministrator)
                 {
                     env.SetStatusCode(401);
+
                     return env.GetCompleted();
                 }
 
@@ -102,6 +103,7 @@ namespace qed
                 dispatcher.Get("/{owner}/{name}", Handlers.GetBuilds);
                 dispatcher.Get("/{owner}/{name}/builds/{id}", Handlers.GetBuild);
                 dispatcher.Post("/{owner}/{name}/builds", forbidIfNotAdministrator, Handlers.PostBuild);
+                dispatcher.Get("/.*", Handlers.Get404);
             }));
         }
     }

--- a/qed/MustacheTemplates/404.mustache
+++ b/qed/MustacheTemplates/404.mustache
@@ -1,0 +1,4 @@
+﻿  <h1>File Not Found</h1>
+  <p>
+    These are not the builds you&#8217;re looking for.
+  </p>

--- a/qed/Program.cs
+++ b/qed/Program.cs
@@ -148,7 +148,7 @@ namespace qed
 
         static void RunBuilds()
         {
-            // TODO: Decide on a better loggin approach
+            // TODO: Decide on a better login approach
             var fail = new Action<Exception>(ex =>
             {
                 Console.WriteLine("BuildNext failed with: ");

--- a/qed/RequestHandlers/Get404.cs
+++ b/qed/RequestHandlers/Get404.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using fn = qed.Functions;
+
+namespace qed
+{
+    public static partial class Handlers
+    {
+        public static Task Get404(
+            IDictionary<string, object> environment,
+            Func<IDictionary<string, object>, Task> next)
+        {
+            return environment.Render("404", null);
+        }
+    }
+}

--- a/qed/qed.csproj
+++ b/qed/qed.csproj
@@ -183,6 +183,7 @@
     <Compile Include="RavenQueries\GetLastFinishedBuild.cs" />
     <Compile Include="RavenQueries\GetBuilds.cs" />
     <Compile Include="RavenQueries\GetBuild.cs" />
+    <Compile Include="RequestHandlers\Get404.cs" />
     <Compile Include="RequestHandlers\PatchUser.cs" />
     <Compile Include="RequestHandlers\GetUsers.cs" />
     <Compile Include="RequestHandlers\DeleteSession.cs" />
@@ -235,6 +236,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="MustacheTemplates\users.mustache">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="MustacheTemplates\404.mustache">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <None Include="packages.config" />


### PR DESCRIPTION
This seems to work fine for most 404 URLs. The problem is the case where the URL matches one of the other patterns, but doesn't match the data.

For example:
- http://localhost:1754/xyz/blah -- 404 page!
- http://localhost:1754/half-ogre/qedxxx -- NADA!

What's the best approach for a dispatcher to hand it off to the next one?
